### PR TITLE
Added 2 new options

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -47,4 +47,10 @@ History
 
 * Enforce description in SCP and correct extension
 
+0.7.0 (2022-08-28)
+------------------
 
+* Added 2 new options
+    --metadata-name -> to customize the name in the metadata
+    --enforce-account-number-only ->  Allows to enforce use of 12 digit account numbers
+    The input scps folder is not mandatory anymore

--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,9 @@ make local-test: local-dist local-install
 	aws_control_tower_manifest_builder --input-cf tests/sample_templates \
 	--input-scp tests/sample_scp \
 	--output tests/output_manifest --default-region us-east-1
+	aws_control_tower_manifest_builder --input-cf tests/sample_templates \
+	--input-scp tests/sample_scp \
+	--output tests/output_manifest --default-region us-east-1 --metadata-name "wrong_metadata_name"
 
 SEMVER_TYPES := major minor patch
 BUMP_TARGETS := $(addprefix bump-,$(SEMVER_TYPES))

--- a/README.rst
+++ b/README.rst
@@ -61,11 +61,12 @@ To bump version:
 .. code-block:: yaml
   
    Metadata:
-     manifest_parameters:
+     manifest_parameters: # can be customized with --metadata-name
      name: detailed_template # Optional. Defaults to the file name. a-z, A-Z, 0-9, and "-"
      description: string # Required for SCPs
      deploy_method: stackset # Optional. All file in the template directory use "stackset" and in policy directory use "scp".
-     accounts: ["123456789012", "987456123989"] # Requires "accounts" and/or "organizational_unit". [0-9]{12}
+     accounts: ["123456789012", "987456123989"] # Requires "accounts" and/or "organizational_unit". If accounts is used, enforce only account
+                                                # IDs with --enforce-account-number-only
      organizational_units: ["dev", "prod"] # Requires "accounts" and/or "organizational_unit".
      regions: ["us-east-1" , "us-east-2"] # Optional. Defaults to us-east-1.
      parameters: # Optional. List of parameters [SSM, Alfred, Values]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,7 +10,7 @@ twine==1.14.0
 setuptools==60.9.3
 
 pytest==6.2.4
-black==21.7b0
+black==22.3.0
 pylint==2.12.2
 
 ruamel.yaml==0.17.20

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.7.0
 commit = False
 tag = False
 

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,6 @@ setup(
     test_suite="tests",
     tests_require=test_requirements,
     url="https://github.com/gabrielbac/aws_control_tower_manifest_builder",
-    version="0.6.0",
+    version="0.7.0",
     zip_safe=False,
 )

--- a/src/aws_control_tower_manifest_builder/__init__.py
+++ b/src/aws_control_tower_manifest_builder/__init__.py
@@ -1,3 +1,3 @@
 """for plint"""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/src/aws_control_tower_manifest_builder/cli.py
+++ b/src/aws_control_tower_manifest_builder/cli.py
@@ -8,8 +8,6 @@ from aws_control_tower_manifest_builder import logger
 
 log = logger.get_logger(__name__)
 
-# TODO: Add verification for inputs
-# TODO: Fix Tox. Add
 # TODO: adding final schema validation
 # TODO: Read me and Docs. connect github and read the docs account.
 
@@ -88,7 +86,6 @@ def main():
         "-s",
         metavar="/path/",
         type=dir_path,
-        required=True,
         help="the path to the directory containing the service control policy \
             input files",
     )
@@ -107,6 +104,23 @@ def main():
         required=False,
         default="2021-03-15",
         help="Schema Version of the Manifest file",
+    )
+
+    parser.add_argument(
+        "--metadata-name",
+        "-m",
+        required=False,
+        default="manifest_parameters",
+        help="Name for the input metadata",
+    )
+
+    parser.add_argument(
+        "--enforce-account-number-only",
+        "-e",
+        required=False,
+        default=False,
+        type=str2bool,
+        help="True to enforce accepting 12 digit account IDs only",
     )
 
     try:

--- a/tests/aws_control_tower_manifest_builder_test.py
+++ b/tests/aws_control_tower_manifest_builder_test.py
@@ -7,17 +7,34 @@ from src.aws_control_tower_manifest_builder.aws_control_tower_manifest_builder i
 from src.aws_control_tower_manifest_builder.manifest_input import Scp, CfTemplate
 
 DEFAULT_REGION = "us-east-1"
-
+METADATA_NAME = "manifest_parameters"
+ENFORCE_ACCOUNT_NUMBER_ONLY = False
 
 OUTPUT_CF = (
     [
         {
             "name": "testS3",
-            "resource_file": "https://s3.amazonaws.com/solutions-reference/\
-customizations-for-aws-control-tower/latest/custom-control-tower-initiation.template",
+            "resource_file": "https://s3.amazonaws.com/solutions-reference/customizations-for-aws-control-tower/latest/custom-control-tower-initiation.template",
             "accounts": ["123456789012", "987456123989"],
             "organizational_units": ["dev", "prod"],
             "regions": ["us-east-1", "us-east-2"],
+            "deploy_method": "stack_set",
+        },
+        {
+            "name": "twoAccounts",
+            "accounts": ["123456789555", "Account-name"],
+            "organizational_units": ["dev", "prod"],
+            "regions": ["us-east-1", "us-east-2"],
+            "resource_file": "tests/sample_templates/cf-template-account-id-and-name.yaml",
+            "deploy_method": "stack_set",
+        },
+        {
+            "name": "templateLocalS3",
+            "description": "Template to deploy S3 buckets",
+            "accounts": ["123456789012", "123"],
+            "organizational_units": ["dev", "prod"],
+            "regions": ["us-east-1", "us-east-2"],
+            "resource_file": "tests/sample_templates/cf-template-account-wrong-length-error.yaml",
             "deploy_method": "stack_set",
         },
         {
@@ -55,7 +72,7 @@ customizations-for-aws-control-tower/latest/custom-control-tower-initiation.temp
             "deploy_method": "stack_set",
         },
     ],
-    4,
+    6,
     6,
 )
 
@@ -84,19 +101,25 @@ input_data = [
 @pytest.mark.parametrize("path, manifest_type, default_region, output", input_data)
 def test_loop_through_files_success(path, manifest_type, default_region, output):
     """Test that number of successes match"""
-    response = loop_through_files(path, manifest_type, default_region)
+    response = loop_through_files(
+        path, manifest_type, default_region, METADATA_NAME, ENFORCE_ACCOUNT_NUMBER_ONLY
+    )
     assert response[1] == output[1]
 
 
 @pytest.mark.parametrize("path, manifest_type, default_region, output", input_data)
 def test_loop_through_files_failures(path, manifest_type, default_region, output):
     """Test that number of failures match"""
-    response = loop_through_files(path, manifest_type, default_region)
+    response = loop_through_files(
+        path, manifest_type, default_region, METADATA_NAME, ENFORCE_ACCOUNT_NUMBER_ONLY
+    )
     assert response[2] == output[2]
 
 
 @pytest.mark.parametrize("path, manifest_type, default_region, output", input_data)
 def test_loop_through_files_resources(path, manifest_type, default_region, output):
     """Test that output matches"""
-    response = loop_through_files(path, manifest_type, default_region)
+    response = loop_through_files(
+        path, manifest_type, default_region, METADATA_NAME, ENFORCE_ACCOUNT_NUMBER_ONLY
+    )
     assert response[0] == output[0]

--- a/tests/output_manifest/manifest.yaml
+++ b/tests/output_manifest/manifest.yaml
@@ -1,74 +1,16 @@
 region: us-east-1
 version: 2021-03-15
 resources: # List of resources
-- name: testS3
-  resource_file: https://s3.amazonaws.com/solutions-reference/customizations-for-aws-control-tower/latest/custom-control-tower-initiation.template      #<String> [Local File Path, S3 URL]
+- name: AccountNotString
+  description: Template to deploy S3 buckets
+  resource_file: tests/sample_templates/cf-template-not-default-metadata-name.yaml      #<String> [Local File Path, S3 URL]
   deployment_targets:   # account and/or organizational unit names
     accounts:   # array of strings, [0-9]{12}
     - 123456789012
-    - 987456123989
     organizational_units:   #array of strings
     - dev
     - prod
   deploy_method: stack_set   # scp | stack_set
-  regions:
-  - us-east-1
-  - us-east-2
-- name: detailed-template
-  resource_file: tests/sample_templates/cf-template-detailed.yaml      #<String> [Local File Path, S3 URL]
-  deployment_targets:   # account and/or organizational unit names
-    accounts:   # array of strings, [0-9]{12}
-    - 123456789012
-    - 987456123989
-    organizational_units:   #array of strings
-    - dev
-    - prod
-  deploy_method: stack_set   # scp | stack_set
-  parameters:   # List of parameters [SSM, Alfred, Values]
-  - parameter_key: parameter1
-    parameter_value: value1
-  - parameter_key: parameter2
-    parameter_value: value2
-  export_outputs:   # list of ssm parameters to store output values
-  - name: /org/member/test-ssm/app-id
-    value: $[output_ApplicationId]
-  regions:
-  - us-east-1
-  - us-east-2
-- name: templateLocalIAM
-  description: Template to deploy baseline IAM resources
-  resource_file: tests/sample_templates/cf-template-local.yaml      #<String> [Local File Path, S3 URL]
-  deployment_targets:   # account and/or organizational unit names
-    accounts:   # array of strings, [0-9]{12}
-    - 123456789012
-    - 987456123989
-    organizational_units:   #array of strings
-    - dev
-    - prod
-  deploy_method: stack_set   # scp | stack_set
-  regions:
-  - us-east-1
-  - us-east-2
-- name: cf-template-minimal
-  resource_file: tests/sample_templates/cf-template-minimal.yaml      #<String> [Local File Path, S3 URL]
-  deployment_targets:   # account and/or organizational unit names
-    accounts:   # array of strings, [0-9]{12}
-    - 123456789012
-    - 987456123989
-  deploy_method: stack_set   # scp | stack_set
-  regions:
-  - us-east-1
-- name: ec2-deny
-  description: ec2 deny
-  resource_file: tests/sample_scp/ec2-deny.json      #<String> [Local File Path, S3 URL]
-  deployment_targets:   # account and/or organizational unit names
-    accounts:   # array of strings, [0-9]{12}
-    - 123456789012
-    - 987456123989
-    organizational_units:   #array of strings
-    - dev
-    - prod
-  deploy_method: scp   # scp | stack_set
   regions:
   - us-east-1
   - us-east-2

--- a/tests/sample_templates/cf-template-account-id-and-name.yaml
+++ b/tests/sample_templates/cf-template-account-id-and-name.yaml
@@ -1,0 +1,6 @@
+Metadata:
+  manifest_parameters:
+    name: twoAccounts
+    accounts: ["123456789555", "Account-name"]
+    organizational_units: ["dev", "prod"]
+    regions: ["us-east-1" , "us-east-2"]

--- a/tests/sample_templates/cf-template-not-default-metadata-name.yaml
+++ b/tests/sample_templates/cf-template-not-default-metadata-name.yaml
@@ -1,0 +1,7 @@
+Metadata:
+  wrong_metadata_name:
+    name: AccountNotString
+    description: "Template to deploy S3 buckets"
+    accounts: ["123456789012"]
+    organizational_units: ["dev", "prod"]
+    regions: ["us-east-1" , "us-east-2"]


### PR DESCRIPTION
--metadata-name -> to customize the name in the metadata
--enforce-account-number-only ->  Allows to enforce use of 12 digit account
numbers
the input scps folder is not mandatory anymore